### PR TITLE
Added Request-ID and Correlation-ID headers to requests

### DIFF
--- a/src/Common/Client/Modules/AbstractFeatures.php
+++ b/src/Common/Client/Modules/AbstractFeatures.php
@@ -46,7 +46,8 @@ class AbstractFeatures
 
         $uri = self::forgeUri($endpointUri, $serverRequestInterface->getUri());
 
-        return $this->addAuthorization($serverRequestInterface->withUri($uri));
+        return $this->addMessageIds($serverRequestInterface, $request)
+            ->addAuthorization($serverRequestInterface->withUri($uri));
     }
 
     protected function addAuthorization(ServerRequestInterface $request): ServerRequestInterface
@@ -70,5 +71,12 @@ class AbstractFeatures
         }
 
         return $uri;
+    }
+
+    protected function addMessageIds(ServerRequestInterface $serverRequestInterface, AbstractRequest $request): ServerRequestInterface
+    {
+        return $serverRequestInterface
+            ->withHeader('X-Request-ID', $request->getRequestId())
+            ->withHeader('X-Correlation-ID', $request->getCorrelationId());
     }
 }

--- a/src/Common/Client/Modules/AbstractRequest.php
+++ b/src/Common/Client/Modules/AbstractRequest.php
@@ -12,6 +12,31 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 abstract class AbstractRequest
 {
+    protected string $requestId;
+    protected string $correlationId;
+    
+    public function getRequestId(): string
+    {
+        $this->requestId = $this->requestId ?? uniqid('rq-', true);
+        return $this->requestId;
+    }
+
+    public function getCorrelationId(): string
+    {
+        $this->correlationId = $this->correlationId ?? uniqid('co-', true);
+        return $this->correlationId;
+    }
+
+    public function setRequestId(string $requestId): void
+    {
+        $this->requestId = $requestId;
+    }
+
+    public function setCorrelationId(string $correlationId): void
+    {
+        $this->correlationId = $correlationId;
+    }
+    
     abstract public function getModule(): BaseModuleId;
 
     abstract public function getVersion(): OcpiVersion;

--- a/src/Versions/V2_2_1/Client/Sender/Commands/Post/PostCommandResultRequest.php
+++ b/src/Versions/V2_2_1/Client/Sender/Commands/Post/PostCommandResultRequest.php
@@ -21,8 +21,11 @@ class PostCommandResultRequest extends AbstractRequest
 
     private CommandResult $result;
 
-    public function __construct(string $responseUrl, CommandResult $result)
+    public function __construct(string $responseUrl, CommandResult $result, string $correlationId = null)
     {
+        if (!empty($correlationId)) {
+            $this->setCorrelationId($correlationId);
+        }
         $this->responseUrl = $responseUrl;
         $this->result = $result;
     }

--- a/src/Versions/V2_2_1/Client/Sender/Commands/Post/PostCommandResultService.php
+++ b/src/Versions/V2_2_1/Client/Sender/Commands/Post/PostCommandResultService.php
@@ -46,7 +46,8 @@ class PostCommandResultService extends AbstractFeatures
         $serverRequestInterface = $request->getServerRequestInterface($this->ocpiConfiguration->getServerRequestFactory(),
             $this->ocpiConfiguration->getStreamFactory());
 
-        return $this->addAuthorization($serverRequestInterface->withUri($endpointUri));
+        return $this->addMessageIds($serverRequestInterface, $request)
+            ->addAuthorization($serverRequestInterface->withUri($endpointUri));
     }
     
 }


### PR DESCRIPTION
Simple implementation 

- Without dependency on ramsey/uuid
- No need to call parent::__construct from all classes that extend AbstractRequest
- Id headers are added at the same place as the authorization headers
- Has test