### PR TITLE
Trigger client error by always calling self::checkStatusCode

### DIFF
--- a/src/Versions/V2_2_1/Client/Receiver/Cdrs/Post/PostCdrResponse.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Cdrs/Post/PostCdrResponse.php
@@ -13,6 +13,7 @@ class PostCdrResponse extends AbstractResponse
 
     public function __construct(ResponseInterface $response)
     {
+        self::checkStatusCode($response);
         $this->responseInterface = $response;
     }
 

--- a/src/Versions/V2_2_1/Client/Receiver/Locations/Patch/PatchLocationResponse.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Locations/Patch/PatchLocationResponse.php
@@ -13,6 +13,7 @@ class PatchLocationResponse extends AbstractResponse
 
     public function __construct(ResponseInterface $response)
     {
+        self::checkStatusCode($response);
         $this->responseInterface = $response;
     }
 

--- a/src/Versions/V2_2_1/Client/Receiver/Locations/Put/PutLocationResponse.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Locations/Put/PutLocationResponse.php
@@ -13,6 +13,7 @@ class PutLocationResponse extends AbstractResponse
 
     public function __construct(ResponseInterface $response)
     {
+        self::checkStatusCode($response);
         $this->responseInterface = $response;
     }
 

--- a/src/Versions/V2_2_1/Client/Receiver/Sessions/Patch/PatchSessionResponse.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Sessions/Patch/PatchSessionResponse.php
@@ -13,6 +13,7 @@ class PatchSessionResponse extends AbstractResponse
 
     public function __construct(ResponseInterface $response)
     {
+        self::checkStatusCode($response);
         $this->responseInterface = $response;
     }
 

--- a/src/Versions/V2_2_1/Client/Receiver/Sessions/Put/PutSessionResponse.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Sessions/Put/PutSessionResponse.php
@@ -13,6 +13,7 @@ class PutSessionResponse extends AbstractResponse
 
     public function __construct(ResponseInterface $response)
     {
+        self::checkStatusCode($response);
         $this->responseInterface = $response;
     }
 

--- a/src/Versions/V2_2_1/Client/Receiver/Tokens/Patch/PatchTokenResponse.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Tokens/Patch/PatchTokenResponse.php
@@ -13,6 +13,7 @@ class PatchTokenResponse extends BaseResponse
 
     public function __construct(ResponseInterface $response)
     {
+        self::checkStatusCode($response);
         $this->responseInterface = $response;
     }
 

--- a/src/Versions/V2_2_1/Client/Receiver/Tokens/Put/PutTokenResponse.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Tokens/Put/PutTokenResponse.php
@@ -13,6 +13,7 @@ class PutTokenResponse extends BaseResponse
 
     public function __construct(ResponseInterface $response)
     {
+        self::checkStatusCode($response);
         $this->responseInterface = $response;
     }
 


### PR DESCRIPTION
Error codes coming from clients are ignored on some requests.
Trigger client error by always calling self::checkStatusCode in constructor on responses that extend AbstractResponse