### PR TITLE
correct Tariffs ModuleId in Tariff Receiver client

### DIFF
--- a/src/Versions/V2_2_1/Client/Receiver/Tariffs/Get/GetTariffRequest.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Tariffs/Get/GetTariffRequest.php
@@ -41,7 +41,7 @@ class GetTariffRequest extends BaseRequest
 
     public function getModule(): ModuleId
     {
-        return ModuleId::SESSIONS();
+        return ModuleId::TARIFFS();
     }
 
     public function getServerRequestInterface(ServerRequestFactoryInterface $serverRequestFactory, ?StreamFactoryInterface $streamFactory): ServerRequestInterface

--- a/src/Versions/V2_2_1/Client/Receiver/Tariffs/Put/PutTariffRequest.php
+++ b/src/Versions/V2_2_1/Client/Receiver/Tariffs/Put/PutTariffRequest.php
@@ -45,7 +45,7 @@ class PutTariffRequest extends AbstractRequest
 
     public function getModule(): ModuleId
     {
-        return ModuleId::SESSIONS();
+        return ModuleId::TARIFFS();
     }
 
     public function getServerRequestInterface(ServerRequestFactoryInterface $serverRequestFactory, ?StreamFactoryInterface $streamFactory): ServerRequestInterface


### PR DESCRIPTION
Made a misstake in my last pull request by setting SESSIONS as moduleId in Tariffs client.