### PR TITLE
Add message Ids on requests that does not extend AbstractRequest

### DIFF
--- a/src/Common/Client/Modules/AbstractFeatures.php
+++ b/src/Common/Client/Modules/AbstractFeatures.php
@@ -73,7 +73,7 @@ class AbstractFeatures
         return $uri;
     }
 
-    protected function addMessageIds(ServerRequestInterface $serverRequestInterface, AbstractRequest $request): ServerRequestInterface
+    protected function addMessageIds(ServerRequestInterface $serverRequestInterface, MessageIdInterface $request): ServerRequestInterface
     {
         return $serverRequestInterface
             ->withHeader('X-Request-ID', $request->getRequestId())

--- a/src/Common/Client/Modules/HasMessageIds.php
+++ b/src/Common/Client/Modules/HasMessageIds.php
@@ -1,18 +1,9 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Chargemap\OCPI\Common\Client\Modules;
 
-use Chargemap\OCPI\Common\Models\BaseModuleId;
-use Chargemap\OCPI\Common\Client\OcpiVersion;
-use Psr\Http\Message\ServerRequestFactoryInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-
-abstract class AbstractRequest implements MessageIdInterface
+trait HasMessageIds
 {
-    use HasMessageIds;
     protected string $requestId;
     protected string $correlationId;
 
@@ -37,9 +28,4 @@ abstract class AbstractRequest implements MessageIdInterface
     {
         $this->correlationId = $correlationId;
     }
-    abstract public function getModule(): BaseModuleId;
-
-    abstract public function getVersion(): OcpiVersion;
-
-    abstract public function getServerRequestInterface(ServerRequestFactoryInterface $serverRequestFactory, ?StreamFactoryInterface $streamFactory): ServerRequestInterface;
 }

--- a/src/Common/Client/Modules/MessageIdInterface.php
+++ b/src/Common/Client/Modules/MessageIdInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Chargemap\OCPI\Common\Client\Modules;
+interface MessageIdInterface
+{
+    public function getRequestId(): string;
+    public function getCorrelationId(): string;
+}

--- a/src/Common/Client/Modules/Versions/GetAvailableVersions/GetAvailableVersionsRequest.php
+++ b/src/Common/Client/Modules/Versions/GetAvailableVersions/GetAvailableVersionsRequest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Chargemap\OCPI\Common\Client\Modules\Versions\GetAvailableVersions;
 
+use Chargemap\OCPI\Common\Client\Modules\HasMessageIds;
+use Chargemap\OCPI\Common\Client\Modules\MessageIdInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class GetAvailableVersionsRequest
+class GetAvailableVersionsRequest implements MessageIdInterface
 {
+    use HasMessageIds;
+    
     private string $versionsUrl;
 
     public function __construct(string $versionsUrl)

--- a/src/Common/Client/Modules/Versions/GetAvailableVersions/GetAvailableVersionsService.php
+++ b/src/Common/Client/Modules/Versions/GetAvailableVersions/GetAvailableVersionsService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Chargemap\OCPI\Common\Client\Modules\Versions\GetAvailableVersions;
 
 use Chargemap\OCPI\Common\Client\Modules\AbstractFeatures;
+use Chargemap\OCPI\Common\Client\Modules\AbstractRequest;
+use Psr\Http\Message\ServerRequestInterface;
 
 class GetAvailableVersionsService extends AbstractFeatures
 {
@@ -17,6 +19,7 @@ class GetAvailableVersionsService extends AbstractFeatures
     public function get(GetAvailableVersionsRequest $request): GetAvailableVersionsResponse
     {
         $serverRequestInterface = $request->getServerRequestInterface($this->ocpiConfiguration->getServerRequestFactory());
+        $serverRequestInterface = $this->addMessageIds($serverRequestInterface, $request);
         $serverRequestInterface = $this->addAuthorization($serverRequestInterface);
         $responseInterface = $this->ocpiConfiguration->getHttpClient()->sendRequest($serverRequestInterface);
         return GetAvailableVersionsResponse::fromResponseInterface($responseInterface);

--- a/src/Versions/V2_1_1/Client/Emsp/Commands/Post/PostCommandResultService.php
+++ b/src/Versions/V2_1_1/Client/Emsp/Commands/Post/PostCommandResultService.php
@@ -45,6 +45,8 @@ class PostCommandResultService extends AbstractFeatures
 
         $serverRequestInterface = $request->getServerRequestInterface($this->ocpiConfiguration->getServerRequestFactory(),
             $this->ocpiConfiguration->getStreamFactory());
+        
+        $serverRequestInterface = $this->addMessageIds($serverRequestInterface, $request);
 
         return $this->addAuthorization($serverRequestInterface->withUri($endpointUri));
     }

--- a/src/Versions/V2_1_1/Client/Versions/GetDetails/GetVersionDetailRequest.php
+++ b/src/Versions/V2_1_1/Client/Versions/GetDetails/GetVersionDetailRequest.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Chargemap\OCPI\Versions\V2_1_1\Client\Versions\GetDetails;
 
+use Chargemap\OCPI\Common\Client\Modules\HasMessageIds;
+use Chargemap\OCPI\Common\Client\Modules\MessageIdInterface;
 use Chargemap\OCPI\Common\Models\VersionEndpoint;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class GetVersionDetailRequest
+class GetVersionDetailRequest implements MessageIdInterface
 {
+    use HasMessageIds;
+
     private VersionEndpoint $versionEndpoint;
 
     public function __construct(VersionEndpoint $versionEndpoint)

--- a/src/Versions/V2_1_1/Client/Versions/GetDetails/GetVersionDetailService.php
+++ b/src/Versions/V2_1_1/Client/Versions/GetDetails/GetVersionDetailService.php
@@ -17,6 +17,7 @@ class GetVersionDetailService extends AbstractFeatures
     public function get(GetVersionDetailRequest $request): GetVersionDetailResponse
     {
         $serverRequestInterface = $request->getServerRequestInterface($this->ocpiConfiguration->getServerRequestFactory());
+        $serverRequestInterface = $this->addMessageIds($serverRequestInterface, $request);
         $serverRequestInterface = $this->addAuthorization($serverRequestInterface);
         $responseInterface = $this->ocpiConfiguration->getHttpClient()->sendRequest($serverRequestInterface);
         return GetVersionDetailResponse::fromResponseInterface($responseInterface);

--- a/src/Versions/V2_2_1/Client/Versions/GetDetails/GetVersionDetailRequest.php
+++ b/src/Versions/V2_2_1/Client/Versions/GetDetails/GetVersionDetailRequest.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Chargemap\OCPI\Versions\V2_2_1\Client\Versions\GetDetails;
 
+use Chargemap\OCPI\Common\Client\Modules\HasMessageIds;
+use Chargemap\OCPI\Common\Client\Modules\MessageIdInterface;
 use Chargemap\OCPI\Common\Models\VersionEndpoint;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-class GetVersionDetailRequest
+class GetVersionDetailRequest implements MessageIdInterface
 {
+    use HasMessageIds;
+
     private VersionEndpoint $versionEndpoint;
 
     public function __construct(VersionEndpoint $versionEndpoint)

--- a/src/Versions/V2_2_1/Client/Versions/GetDetails/GetVersionDetailService.php
+++ b/src/Versions/V2_2_1/Client/Versions/GetDetails/GetVersionDetailService.php
@@ -17,6 +17,7 @@ class GetVersionDetailService extends AbstractFeatures
     public function get(GetVersionDetailRequest $request): GetVersionDetailResponse
     {
         $serverRequestInterface = $request->getServerRequestInterface($this->ocpiConfiguration->getServerRequestFactory());
+        $serverRequestInterface = $this->addMessageIds($serverRequestInterface, $request);
         $serverRequestInterface = $this->addAuthorization($serverRequestInterface);
         $responseInterface = $this->ocpiConfiguration->getHttpClient()->sendRequest($serverRequestInterface);
         return GetVersionDetailResponse::fromResponseInterface($responseInterface);


### PR DESCRIPTION
Message Id are missing on Version-requests in the Credentials and registration flow (which actually broke one of our integrations). Since GetAvailableVersionsRequest and GetVersionDetailRequest does not extend AbstractRequest I'm suggesting here to add a common trait and interface to share code between these.