### PR TITLE
Fix typo UNKOWN_SESSION > UNKNOWN_SESSION in commands.schema

### DIFF
--- a/resources/jsonSchemas/V2_1_1/Common/commands.schema.json
+++ b/resources/jsonSchemas/V2_1_1/Common/commands.schema.json
@@ -151,7 +151,7 @@
                         "REJECTED",
                         "ACCEPTED",
                         "TIMEOUT",
-                        "UNKOWN_SESSION"
+                        "UNKNOWN_SESSION"
                     ]
                 }
             },

--- a/resources/jsonSchemas/V2_2_1/Common/commands.schema.json
+++ b/resources/jsonSchemas/V2_2_1/Common/commands.schema.json
@@ -197,7 +197,7 @@
                         "NOT_SUPPORTED",
                         "REJECTED",
                         "ACCEPTED",
-                        "UNKOWN_SESSION"
+                        "UNKNOWN_SESSION"
                     ]
                 },
                 "timeout": {


### PR DESCRIPTION
Command validation fails because of typo in schema