### PR TITLE
use propert_exists to check for missing object property status_code

### DIFF
--- a/src/Common/Client/Modules/AbstractResponse.php
+++ b/src/Common/Client/Modules/AbstractResponse.php
@@ -51,7 +51,7 @@ abstract class AbstractResponse
         } catch (JsonException $exception) {
             throw new OcpiInvalidPayloadClientError('Received payload is not valid JSON');
         }
-        if (!$jsonObject->status_code) {
+        if (!property_exists($jsonObject, 'status_code')) {
             throw new OcpiInvalidPayloadClientError('Received payload is missing a status code');
         }
         // Check for 1000+ status codes


### PR DESCRIPTION
Old code:
if (!$jsonObject->status_code) {

throws an error if the property does not exist