### PR TITLE
allow null on tariff price component VAT and on CDR signed_data

### DIFF
--- a/resources/jsonSchemas/V2_2_1/Common/cdr.schema.json
+++ b/resources/jsonSchemas/V2_2_1/Common/cdr.schema.json
@@ -160,7 +160,10 @@
             }
         },
         "signed_data": {
-            "type": "object",
+            "type": [
+                "null",
+                "object"
+            ],
             "properties": {
                 "encoding_method": {
                     "type": "string",

--- a/resources/jsonSchemas/V2_2_1/Common/tariff.schema.json
+++ b/resources/jsonSchemas/V2_2_1/Common/tariff.schema.json
@@ -268,7 +268,10 @@
                             "minimum": 0
                         },
                         "vat": {
-                            "type": "number",
+                            "type": [
+                                "number",
+                                "null"
+                            ],
                             "minimum": 0
                         },
                         "step_size": {


### PR DESCRIPTION
Fields with cardinality "?" should allow null. Fixes two of those:

Tariff price component VAT and on CDR signed_data