### PR TITLE
Lat and Lon should be 5-7 decimals in 2.2.1

### DIFF
--- a/resources/jsonSchemas/V2_2_1/Common/common.schema.json
+++ b/resources/jsonSchemas/V2_2_1/Common/common.schema.json
@@ -283,13 +283,13 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 10,
-            "pattern": "^-?[0-9]{1,2}\\.[0-9]{6}$"
+            "pattern": "^-?[0-9]{1,2}\\.[0-9]{5,7}$"
         },
         "longitude": {
             "type": "string",
             "minLength": 1,
             "maxLength": 11,
-            "pattern": "^-?[0-9]{1,3}\\.[0-9]{6}$"
+            "pattern": "^-?[0-9]{1,3}\\.[0-9]{5,7}$"
         },
         "geo_location": {
             "type": "object",


### PR DESCRIPTION
As per https://github.com/ocpi/ocpi/blob/develop-2.2.1/mod_locations.asciidoc#1413-geolocation-class

Was 6, changed to 5-7