### PR TITLE
Allow zero-length display text strings

### DIFF
--- a/resources/jsonSchemas/V2_1_1/Common/common.schema.json
+++ b/resources/jsonSchemas/V2_1_1/Common/common.schema.json
@@ -267,7 +267,7 @@
                 },
                 "text": {
                     "type": "string",
-                    "minLength": 1,
+                    "minLength": 0,
                     "maxLength": 512
                 }
             },

--- a/resources/jsonSchemas/V2_2_1/Common/common.schema.json
+++ b/resources/jsonSchemas/V2_2_1/Common/common.schema.json
@@ -355,7 +355,7 @@
                 },
                 "text": {
                     "type": "string",
-                    "minLength": 1,
+                    "minLength": 0,
                     "maxLength": 512
                 }
             },


### PR DESCRIPTION
The json schema rules for DisplayText has a restriction on min length: 1 for the text. There is no requirement in the OCPI protocol to support this. The spec says string(512) which in most other situations (database schemas etc) allows for empty strings.

This commit sets the min length to 0.