### PR TITLE
Check null before looping over value

### DIFF
--- a/src/Versions/V2_2_1/Common/Factories/EnergyMixFactory.php
+++ b/src/Versions/V2_2_1/Common/Factories/EnergyMixFactory.php
@@ -25,13 +25,13 @@ class EnergyMixFactory
             property_exists($json, 'energy_product_name') ? $json->energy_product_name : null
         );
 
-        if (property_exists($json, 'energy_sources')) {
+        if (property_exists($json, 'energy_sources') && $json->energy_sources !== null) {
             foreach ($json->energy_sources as $source) {
                 $energyMix->addEnergySource(EnergySourceFactory::fromJson($source));
             }
         }
 
-        if (property_exists($json, 'environ_impact')) {
+        if (property_exists($json, 'environ_impact') && $json->environ_impact !== null) {
             foreach ($json->environ_impact as $impact) {
                 $energyMix->addEnvironImpact(EnvironmentalImpactFactory::fromJson($impact));
             }

--- a/src/Versions/V2_2_1/Common/Factories/SignedDataFactory.php
+++ b/src/Versions/V2_2_1/Common/Factories/SignedDataFactory.php
@@ -22,7 +22,7 @@ class SignedDataFactory
             $json->url ?? null
         );
 
-        if (property_exists($json, 'signed_values')) {
+        if (property_exists($json, 'signed_values') && $json->signed_values !== null) {
             foreach ($json->signed_values as $svJson) {
                 $signedValue = SignedValueFactory::fromJson($svJson);
                 if ($signedValue) {

--- a/src/Versions/V2_2_1/Common/Factories/TariffFactory.php
+++ b/src/Versions/V2_2_1/Common/Factories/TariffFactory.php
@@ -51,7 +51,7 @@ class TariffFactory
             new DateTime($json->last_updated)
         );
 
-        if (property_exists($json, 'tariff_alt_text')) {
+        if (property_exists($json, 'tariff_alt_text') && $json->tariff_alt_text !== null) {
             foreach ((array)DisplayTextFactory::arrayFromJsonArray($json->tariff_alt_text) as $displayText) {
                 $tariff->addTariffAltText($displayText);
             }

--- a/src/Versions/V2_2_1/Common/Factories/TariffRestrictionsFactory.php
+++ b/src/Versions/V2_2_1/Common/Factories/TariffRestrictionsFactory.php
@@ -33,7 +33,7 @@ class TariffRestrictionsFactory
             isset($json->reservation) ? new ReservationRestrictionType($json->reservation) : null
         );
 
-        if (property_exists($json, 'day_of_week')) {
+        if (property_exists($json, 'day_of_week') && $json->day_of_week !== null) {
             foreach ($json->day_of_week as $jsonDayOfWeek) {
                 $tariffRestrictions->addDayOfWeek(
                     new DayOfWeek($jsonDayOfWeek)


### PR DESCRIPTION
Spec allows null for optional arrays, check null before looping through value so we don't try to "foreach" a null value.