### PR TITLE
Do not output empty day_of_week array on TariffRestrictions

### DIFF
--- a/src/Versions/V2_2_1/Common/Models/TariffRestrictions.php
+++ b/src/Versions/V2_2_1/Common/Models/TariffRestrictions.php
@@ -150,10 +150,11 @@ class TariffRestrictions implements JsonSerializable
 
     public function jsonSerialize(): array
     {
-        $return = [
-            'day_of_week' => $this->daysOfWeek,
-        ];
+        $return = [];
 
+        if (!empty($this->daysOfWeek)) {
+             $return['day_of_week'] = $this->daysOfWeek;
+        }
         if ($this->startTime !== null) {
             $return['start_time'] = $this->startTime;
         }


### PR DESCRIPTION
When a Tariff element har restrictions but not day of week restrictions we should not print an empty array. This could be interpreted as "valid no days of week" and cause bugs. Better to omit it if not relevant.
`"restrictions": {
            "day_of_week": [],
            "start_time": "22:00",
            "end_time": "06:00"
          }`
becomes
`"restrictions": {
            "start_time": "22:00",
            "end_time": "06:00"
          }`