### PR TITLE
Allow the use of psr/log version 3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.4|^8",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "psr/log": "^1.1|^2.0",
+        "psr/log": "^1.1|^2.0|^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
Modern frameworks are using the later version of psr/log and it conflicts when trying to install this package.